### PR TITLE
Add Electron 2.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - nodejs_version: "8.0"
     electron_version: "1.8.3"
+  - nodejs_version: "8.9.3"
+    electron_version: "2.0.2"
 
 platform:
   - x64

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "windows-security",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "name": "windows-security",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "github",
     "url": "https://github.com/mullvad/windows-security"


### PR DESCRIPTION
This PR adds support for Electron 2.0.2. Node 8 and 8.9.3 actually share the same ABI so it's likely that the same binary is built twice but I didn't want to spend time trying to decouple targets which currently come with node and electron versions side-by-side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/windows-security/5)
<!-- Reviewable:end -->
